### PR TITLE
Feat/improve add dependency functionality

### DIFF
--- a/src/main/java/org/buildcli/BuildCLI.java
+++ b/src/main/java/org/buildcli/BuildCLI.java
@@ -19,8 +19,8 @@ public class BuildCLI implements Runnable {
     @Option(names = {"-c", "--compile"}, description = "Compile a Java Project")
     boolean compile;
 
-    @Option(names = {"--add-dependency"}, description = "Add a dependency in 'groupId:artifactId' format")
-    String dependency;
+    @Option(names = {"--add-dependency"}, split = ",", description = "Add a dependency in 'groupId:artifactId' format")
+    String[] dependency;
 
     @Option(names = {"-p", "--profile"}, description = "Create a configuration profile")
     String profile;

--- a/src/main/java/org/buildcli/BuildCLI.java
+++ b/src/main/java/org/buildcli/BuildCLI.java
@@ -19,7 +19,7 @@ public class BuildCLI implements Runnable {
     @Option(names = {"-c", "--compile"}, description = "Compile a Java Project")
     boolean compile;
 
-    @Option(names = {"--add-dependency"}, split = ",", description = "Add a dependency in 'groupId:artifactId' format")
+    @Option(names = {"--add-dependency"}, split = ",", description = "Add a dependency in 'groupId:artifactId' or 'groupId:artifactId:version' format")
     String[] dependency;
 
     @Option(names = {"-p", "--profile"}, description = "Create a configuration profile")

--- a/src/main/java/org/buildcli/utils/PomUtils.java
+++ b/src/main/java/org/buildcli/utils/PomUtils.java
@@ -11,26 +11,41 @@ public class PomUtils {
     private static final Logger logger = Logger.getLogger(PomUtils.class.getName());
     private static final String file = "pom.xml";
 
-    public static void addDependencyToPom(String dependency) {
-        String[] parts = dependency.split(":");
-        if (parts.length != 2) {
-            logger.warning("Invalid dependency format. Use 'groupId:artifactId'.");
-            return;
+    public static void addDependencyToPom(String[] dependency) {
+
+        StringBuilder dependencyXml = new StringBuilder();
+        for(String d : dependency) {
+            String[] parts = d.split(":");
+
+            switch (parts.length) {
+                case 2:
+                    parts = (d + ":LATEST").split(":");
+                    break;
+                case 3:
+                    break;
+                default:
+                    logger.warning("Invalid dependency format. Use 'groupId:artifactId'" +
+                            "or 'groupId:artifactId:version'.");
+                    return;
+            }
+
+            dependencyXml.append( """
+                            <--! Add by BuildCLI-->
+                            <dependency>
+                                <groupId>%s</groupId>
+                                <artifactId>%s</artifactId>
+                                <version>%s</version>
+                            </dependency>
+                    """.formatted(parts[0], parts[1], parts[2]));
         }
 
-        String dependencyXml = """
-                                <--! Add by BuildCLI-->
-                                <dependency>
-                                    <groupId>%s</groupId>
-                                    <artifactId>%s</artifactId>
-                                    <version>LATEST</version>
-                                </dependency>
-                            </dependencies>\
-                        """.formatted(parts[0], parts[1]);
+        dependencyXml.append("""
+                                </dependencies>\
+                            """);
 
         try {
             String pomContent = new String(Files.readAllBytes(Paths.get(file)));
-            pomContent = pomContent.replace("</dependencies>", dependencyXml);
+            pomContent = pomContent.replace("    </dependencies>", dependencyXml);
             Files.write(Paths.get(file), pomContent.getBytes());
             System.out.println("Dependency added to pom.xml.");
         } catch (IOException e) {


### PR DESCRIPTION
## Description

 Improve --add-dependency functionality
 - Add the capability of function to specify the version of dependency;
 - Add the capability of function to add more than one dependency per statement;

## Related Issues

## Changes

 - To specify the version of a dependency, use the format groupId:artifactId:version;
 - For multi-dependencies, user ',' between then;
 - Updated description of --add-dependency

## Testing

 --add-dependency com.auth0:java-jwt,com.auth0:java-jwt:4.4.0

### Checklist
- [x] My code follows the code style of this project
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run tests to check that my changes do not break existing code

## Additional Notes
N/A
