### PR TITLE
Improve --add-dependency, add option --rm-dependency

### DIFF
--- a/src/main/java/org/buildcli/BuildCLI.java
+++ b/src/main/java/org/buildcli/BuildCLI.java
@@ -22,6 +22,9 @@ public class BuildCLI implements Runnable {
     @Option(names = {"--add-dependency"}, split = ",", description = "Add a dependency in 'groupId:artifactId' or 'groupId:artifactId:version' format")
     String[] dependency;
 
+    @Option(names = {"--rm-dependency"}, split = ",", description = "Remove a dependency in 'groupId:artifactId' format")
+    String[] rmDependency;
+
     @Option(names = {"-p", "--profile"}, description = "Create a configuration profile")
     String profile;
 
@@ -43,6 +46,8 @@ public class BuildCLI implements Runnable {
                 new ProjectCompiler().compileProject();
             } else if (dependency != null) {
                 PomUtils.addDependencyToPom(dependency);
+            } else if (rmDependency != null) {
+                PomUtils.rmDependencyToPom(rmDependency);
             } else if (profile != null) {
                 ProjectInitializer.createProfileConfig(profile);
             } else if (run) {

--- a/src/main/java/org/buildcli/utils/Pom.java
+++ b/src/main/java/org/buildcli/utils/Pom.java
@@ -1,0 +1,182 @@
+package org.buildcli.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+public class Pom {
+
+    private final List<Dependency> dependencies = new ArrayList<>();
+    private static final Logger logger = Logger.getLogger(Pom.class.getName());
+
+    public void addDependency(String dependency) {
+        String[] parts = dependency.split(":");
+
+        switch (parts.length) {
+            case 2:
+                addDependency(parts[0], parts[1]);
+                break;
+            case 3:
+                addDependency(parts[0], parts[1], parts[2]);
+                break;
+            default:
+                logger.warning("Invalid dependency format. Use 'groupId:artifactId'" +
+                        "or 'groupId:artifactId:version'.");
+        }
+    }
+
+    void addDependency(String groupId, String artifactId, String version) {
+        dependencies.stream()
+                .filter(d -> d.getArtifactId()
+                        .equals(artifactId) && d.getGroupId().equals(groupId))
+                .findFirst()
+                .ifPresentOrElse(f -> f.setVersion(version),
+                        () -> dependencies.add(new Dependency(groupId, artifactId, version)));
+    }
+
+    void addDependency(String groupId, String artifactId) {
+        addDependency(groupId, artifactId, "LATEST");
+    }
+
+    void addDependencyFile(String groupId, String artifactId, String version, String type, String scope, String optional) {
+        dependencies.add(new Dependency(groupId, artifactId, version, type, scope, optional));
+    }
+
+    public void rmDependency(String dependency) {
+        String[] parts = dependency.split(":");
+        switch (parts.length) {
+            case 2,3:
+                rmDependency(parts[0], parts[1]);
+                break;
+            default:
+                logger.warning("Invalid dependency format. Use 'groupId:artifactId'" +
+                        "or 'groupId:artifactId:version'.");
+        }
+    }
+
+    public void rmDependency(String groupId, String artifactId) {
+        dependencies.remove(dependencies.stream()
+                .filter(d -> d.getArtifactId().equals(artifactId) && d.getGroupId().equals(groupId))
+                .findFirst().orElse(null));
+    }
+
+    public String getDependencyFormatted(){
+        StringBuilder result = new StringBuilder();
+        result.append("""
+                                <dependencies>
+                            """);
+        for (Dependency dependency : dependencies) {
+            result.append( """
+                            <!-- Added by BuildCLI-->
+                            <dependency>
+                                <groupId>%s</groupId>
+                                <artifactId>%s</artifactId>
+                                <version>%s</version>
+                    """.formatted(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion()));
+            if(dependency.getType() != null)
+                result.append("""
+                                    <type>%s</type>
+                        """.formatted(dependency.getType()));
+            if (dependency.getScope() != null)
+                result.append("""
+                                    <scope>%s</scope>
+                        """.formatted(dependency.getScope()));
+            if (dependency.getOptional() != null)
+                result.append("""
+                                    <optional>%s</optional>
+                        """.formatted(dependency.getOptional()));
+            result.append( """
+                                    </dependency>
+                            """);
+        }
+        result.append("""
+                                </dependencies>\
+                            """);
+        return result.toString();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("[");
+        dependencies.forEach(dependency -> {sb.append(dependency.getGroupId())
+                .append(":")
+                .append(dependency.getArtifactId())
+                .append(":")
+                .append(dependency.getVersion())
+                .append(",");});
+        sb.append("]");
+        return sb.toString();
+    }
+}
+
+class Dependency{
+    private String groupId;
+    private String artifactId;
+    private String version;
+    private String type;
+    private String scope;
+    private String optional;
+
+    public Dependency(String groupId, String artifactId, String version) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+    }
+
+    public Dependency(String groupId, String artifactId, String version, String type, String scope, String optional) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+        this.type = type;
+        this.scope = scope;
+        this.optional = optional;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public String getOptional() {
+        return optional;
+    }
+
+    public void setOptional(String optional) {
+        this.optional = optional;
+    }
+}

--- a/src/main/java/org/buildcli/utils/PomUtils.java
+++ b/src/main/java/org/buildcli/utils/PomUtils.java
@@ -1,8 +1,10 @@
 package org.buildcli.utils;
 
-import java.io.IOException;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -10,46 +12,110 @@ public class PomUtils {
 
     private static final Logger logger = Logger.getLogger(PomUtils.class.getName());
     private static final String file = "pom.xml";
+    private static StringBuilder pomData =  new StringBuilder();
+    private static Pom pom = new Pom();
 
     public static void addDependencyToPom(String[] dependency) {
-
-        StringBuilder dependencyXml = new StringBuilder();
-        for(String d : dependency) {
-            String[] parts = d.split(":");
-
-            switch (parts.length) {
-                case 2:
-                    parts = (d + ":LATEST").split(":");
-                    break;
-                case 3:
-                    break;
-                default:
-                    logger.warning("Invalid dependency format. Use 'groupId:artifactId'" +
-                            "or 'groupId:artifactId:version'.");
-                    return;
-            }
-
-            dependencyXml.append( """
-                            <!-- Added by BuildCLI-->
-                            <dependency>
-                                <groupId>%s</groupId>
-                                <artifactId>%s</artifactId>
-                                <version>%s</version>
-                            </dependency>
-                    """.formatted(parts[0], parts[1], parts[2]));
-        }
-
-        dependencyXml.append("""
-                                </dependencies>\
-                            """);
-
+        extractPomFile();
+        for(String d : dependency)
+            pom.addDependency(d);
         try {
-            String pomContent = new String(Files.readAllBytes(Paths.get(file)));
-            pomContent = pomContent.replace("    </dependencies>", dependencyXml);
+            String pomContent = pomData.toString()
+                    .replace("##dependencies##", pom.getDependencyFormatted());
             Files.write(Paths.get(file), pomContent.getBytes());
             System.out.println("Dependency added to pom.xml.");
         } catch (IOException e) {
             logger.log(Level.SEVERE, "Error adding dependency to pom.xml", e);
         }
+    }
+
+    public static void rmDependencyToPom(String[] rmDependency) {
+        extractPomFile();
+        for(String d : rmDependency)
+            pom.rmDependency(d);
+
+        try {
+            String pomContent = pomData.toString()
+                    .replace("##dependencies##", pom.getDependencyFormatted());
+            Files.write(Paths.get(file), pomContent.getBytes());
+            System.out.println("Dependency removed from pom.xml.");
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Error adding dependency to pom.xml", e);
+        }
+    }
+
+    private static void extractPomFile(){
+        Pom newPom = new Pom();
+
+        StringBuilder newPomData = new StringBuilder();
+
+        File pomFile = new File(Paths.get(file).toFile().getAbsolutePath());
+        try(Reader reader = new FileReader(pomFile);
+            BufferedReader br = new BufferedReader(reader)) {
+
+            fileWhile: while(br.ready()) {
+                String readLine = br.readLine();
+                if(readLine.contains("<dependencies>")) {
+                    String line = br.readLine();
+                    while(!line.contains("</dependencies>")) {
+                        if(line.contains("<dependency>")) {
+                            Map<String,String> dependency = new HashMap<>();
+                            while(!line.contains("</dependency>")) {
+                                line = br.readLine();
+                                if(line.contains("<groupId>")) {
+                                    dependency.put("groupId",
+                                            line.replace("<groupId>", "")
+                                                    .replace("</groupId>", "")
+                                                    .strip());
+                                    continue;
+                                }
+                                if(line.contains("<artifactId>")) {
+                                    dependency.put("artifactId",
+                                            line.replace("<artifactId>", "")
+                                                    .replace("</artifactId>", "")
+                                                    .strip());
+                                    continue;
+                                }
+                                if(line.contains("<version>")) {
+                                    dependency.put("version", line.replace("<version>", "")
+                                            .replace("</version>", "")
+                                            .strip());
+                                    continue;
+                                }
+                                if(line.contains("<type>")) {
+                                    dependency.put("type", line.replace("<type>", "")
+                                            .replace("</type>", "")
+                                            .strip());
+                                    continue;
+                                }
+                                if(line.contains("<scope>")) {
+                                    dependency.put("scope", line.replace("<scope>", "")
+                                            .replace("</scope>", "")
+                                            .strip());
+                                    continue;
+                                }
+                                if(line.contains("<optional>"))
+                                    dependency.put("optional", line.replace("<optional>", "")
+                                            .replace("</optional>", "")
+                                            .strip());
+                            }
+                            newPom.addDependencyFile(dependency.get("groupId"),dependency.get("artifactId"),
+                                    dependency.get("version"), dependency.get("type"), dependency.get("scope"),
+                                    dependency.get("optional"));
+                            //continue fileWhile;
+                            line = br.readLine();
+                        } else
+                            line = br.readLine();
+                    }
+                    newPomData.append("##dependencies##").append(System.lineSeparator());
+                } else
+                    newPomData.append(readLine).append(System.lineSeparator());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        pomData = newPomData;
+        pom = newPom;
     }
 }


### PR DESCRIPTION
## Description

 - Improve --add-dependency to replace older entry for the new one with the same gruopId:artifactId, instead of only add a new entry to the file;
 - Add capability to remove, --rm-dependency=<gruopId:artifactId> option

## Related Issues
N/A

## Changes
 - Create a new class Pom.java that contains pom file properties;
 - Refactory the PomUtil.java;
 - Add option --rm-dependency to BuildCLI.java

## Testing

 - Add dependency;
 - Add one more once the same dependency and open pom.xml life and search for duplicate dependency entries;
 - Add the same dependency with the other version search for the entry, and look if it is updated;
 - Remove the entry and search in the pom file if the entry was removed;

### Checklist
- [x] My code follows the code style of this project
- [ ] I have added necessary documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run tests to check that my changes do not break existing code

## Additional Notes
N/A