### PR TITLE
:card_file_box: feat: add color to log output based on severity | Issue #39 Add Color to Terminal Output 

### DIFF
--- a/src/main/java/org/buildcli/BuildCLI.java
+++ b/src/main/java/org/buildcli/BuildCLI.java
@@ -3,6 +3,7 @@ package org.buildcli;
 import java.util.Objects;
 
 import org.buildcli.log.SystemOutLogger;
+import org.buildcli.log.config.LoggingConfig;
 import org.buildcli.utils.BuildCLIIntro;
 
 import picocli.CommandLine;
@@ -18,6 +19,8 @@ public class BuildCLI implements Runnable {
     private OptionCommand optionCommand;
 
     public static void main(String[] args) {
+        LoggingConfig.configure();
+
         int exitCode = new CommandLine(new BuildCLI()).execute(args);
         System.exit(exitCode);
     }

--- a/src/main/java/org/buildcli/log/ColorConsoleHandler.java
+++ b/src/main/java/org/buildcli/log/ColorConsoleHandler.java
@@ -1,0 +1,21 @@
+package org.buildcli.log;
+
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+public class ColorConsoleHandler extends ConsoleHandler {
+
+    @Override
+    public synchronized void publish(LogRecord record){
+        if(record.getLevel()== Level.INFO){
+            record.setMessage("\u001B[32m" + record.getMessage() + "\u001B[0m");
+        } else if (record.getLevel() == Level.WARNING) {
+            record.setMessage("\u001B[33m" + record.getMessage() + "\u001B[0m");
+        } else if (record.getLevel() == Level.SEVERE) {
+            record.setMessage("\u001B[31m" + record.getMessage() + "\u001B[0m");
+        }
+
+        super.publish(record);
+    }
+}

--- a/src/main/java/org/buildcli/log/config/LoggingConfig.java
+++ b/src/main/java/org/buildcli/log/config/LoggingConfig.java
@@ -1,0 +1,23 @@
+package org.buildcli.log.config;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.LogManager;
+
+public class LoggingConfig {
+
+    private LoggingConfig() {
+    }
+
+    public static void configure() {
+        try (InputStream configFile = LoggingConfig.class.getResourceAsStream("/logging.properties")) {
+            if (configFile != null) {
+                LogManager.getLogManager().readConfiguration(configFile);
+            } else {
+                System.err.println("Could not find logging.properties file.");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,0 +1,2 @@
+handlers=org.buildcli.log.ColorConsoleHandler
+.level=ALL


### PR DESCRIPTION
- ColorConsoleHandler: defines colors based on log severity
- logging.properties: created a file with ColorConsoleHandler as the default handler for Logger
- LoggingConfig: class to load and identify the configuration file

- BuildCLI: initialize default Logger handler in main

https://github.com/wheslleyrimar/BuildCLI/issues/39