### PR TITLE
feat: Implemented an --about Command | Issue #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Options:
       --cicd-config         Configure CI/CD for the specified tool (e.g., github, gitlab, jenkins)
   -h, --help                Shows help
   -V, --version             Shows the version of BuildCLI
+  -a, --about               Displays project information, including its purpose, repository, and contributors.
 ```
 
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,10 @@
 								<transformer
 									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<mainClass>org.buildcli.BuildCLI</mainClass>
+									<manifestEntries>
+										<!-- Define o diretório de origem do JAR -->
+										<Build-Directory>${project.basedir}</Build-Directory>
+									</manifestEntries>
 								</transformer>
 							</transformers>
 						</configuration>

--- a/src/main/java/org/buildcli/OptionCommand.java
+++ b/src/main/java/org/buildcli/OptionCommand.java
@@ -56,4 +56,7 @@ public class OptionCommand {
 
     @Option(names = {"--cicd-config"}, description = "Configure CI/CD for the specified tool (e.g., github, gitlab, jenkins)")
     String cicdTool;
+
+    @Option(names = {"-a","--about"}, description = "Displays project information, including its purpose, repository, and contributors.")
+    boolean about;
 }

--- a/src/main/java/org/buildcli/OptionCommandMap.java
+++ b/src/main/java/org/buildcli/OptionCommandMap.java
@@ -48,5 +48,7 @@ public class OptionCommandMap extends HashMap<String, CommandExecutor> {
 			}
 			new CICDManager().configureCICD(optionCommand.cicdTool);
 		});
+		this.put("--about", () -> new BuildCLIIntro().about());
+		this.put("-a", () -> new BuildCLIIntro().about());
 	}
 }

--- a/src/main/java/org/buildcli/utils/BuildCLIIntro.java
+++ b/src/main/java/org/buildcli/utils/BuildCLIIntro.java
@@ -15,7 +15,7 @@ import org.buildcli.log.SystemOutLogger;
 * */
 public class BuildCLIIntro {
 
-	private BuildCLIIntro() { }
+	public BuildCLIIntro() { }
 
     public static void welcome(){
     	SystemOutLogger.log(",-----.          ,--.,--.   ,--. ,-----.,--.   ,--.");
@@ -25,4 +25,18 @@ public class BuildCLIIntro {
     	SystemOutLogger.log("`------'  `----' `--'`--' `---'  `-----'`-----'`--'");
     	SystemOutLogger.log("");
     }
+
+	public static void about() {
+		SystemOutLogger.log("BuildCLI is a command-line interface (CLI) tool for managing and automating common tasks in Java project development.\n" +
+				"It allows you to create, compile, manage dependencies, and run Java projects directly from the terminal, simplifying the development process.\n");
+		SystemOutLogger.log("Visit the repository for more details: https://github.com/wheslleyrimar/BuildCLI\n");
+
+		String contributors = new ReleaseManager().showContributors();
+
+		SystemOutLogger.log("Contributors:\n");
+		SystemOutLogger.log(contributors);
+
+
+	}
+
 }


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes introduced by this PR -->
Displays project information, including its purpose, repository, and contributors.
## Related Issues
<!-- Link any related issues or tasks. Use keywords to automatically close issues, e.g., Fixes #123 -->
Fixes #46 - Add an --about Command

## Changes
- [x] Implemented ```buildcli --about``` and ```buildcli -a``` commands to display the following information:
    - Purpose of BuildCLI
    - The project's repository
    - A list of voluntary contributors
- [x] Implemented new methods in utils.RealeaseManager.java
    - ```runGitCommandAndShowOutput```: Executes a Git command and captures its output, throwing an exception if the command fails.
    - ```showContributors```: Retrieves and return the list of contributors from a local Git repository.
    - ```findGitRepository```: Finds the path of a local Git repository based on the given directory path.
    - ```getBuildCLIBuildDirectory```: Retrieves the build directory path from the MANIFEST.MF file inside the JAR.
- [x] Implemented new method in utils.BuildCLIIntro.java
    - ```about```: Displays project purpose, repository and contributors.

## Testing
<!-- Describe how the changes were tested, and include any testing steps, screenshots, or other verification details -->
- Git command executed in the home directory, but displaying the result from another directory. 

![comando git executado na home](https://github.com/user-attachments/assets/c7557060-045b-4cbd-9cf7-48ea82f171bf)

- Executing java -jar in the local repository:

![java -jar --about](https://github.com/user-attachments/assets/59fdd5e2-838c-4d1e-b10c-c0dded8d216b)

- `buildcli -a` and its results, along with the location of the buildcli .jar:

![buildcli -a](https://github.com/user-attachments/assets/d4c8f5ff-7652-4bfc-9c0c-d0056e2ef991)

### Checklist
- [x] My code follows the code style of this project
- [x] I have added necessary documentation (if applicable)
- [x] I have run tests to check that my changes do not break existing code

## Additional Notes
<!-- Add any other relevant information or comments -->

- I think it's possible to create a new issue to update BuildCLI directly from a BuildCLI command because now we have the user's local repository in the .jar, in addition to its location. So, it would be possible to run a `git pull`, `mvn package`, and then copy the updated .jar to the installation path.
- ```ReleaseManger.showContributors()```: return the list of contributors from a local Git repository through this command:
 

    - ```sh -c "git --git-dir=<example/path/app/.git> --work-tree=<example/path/app/> log --format='- %aN <%aE>' | sort | uniq"```

# :sparkles: Happy New Year! :sparkles: