### PR TITLE
fix(logging): Clean up log output and fix Logback config

### DIFF
--- a/src/main/java/org/buildcli/log/SystemOutLogger.java
+++ b/src/main/java/org/buildcli/log/SystemOutLogger.java
@@ -8,11 +8,10 @@ import org.slf4j.LoggerFactory;
 public class SystemOutLogger {
 
 	private static final Logger logger = LoggerFactory.getLogger(BuildCLI.class);
-	
+
 	private SystemOutLogger() { }
-	
+
 	public static void log(String message) {
 		logger.info(message);
-		logger.info("\n");
 	}
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,20 +1,22 @@
-<configuration>
+<configuration debug="false">
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>${user.home}/logs/buildcli.log</file>
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
 
-  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-    <file>${user.home}/logs/builcli.log</file>
-    <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36}-%msg%n</pattern>
-    </encoder>
-  </appender>
-  <appender-ref ref="FILE" />
-
-  <root level="DEBUG">
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="FILE" />
   </root>
+
 </configuration>


### PR DESCRIPTION
- Removed extra newlines in SystemOutLogger to prevent cluttered logs  
- Disabled Logback internal logs to reduce noise  
- Fixed appender-ref warnings in logback.xml  
- Set log level to INFO for cleaner output  