### PR TITLE
Update description to specify BuildCLI instead of CLI in version command

### DIFF
--- a/src/main/java/org/buildcli/commands/VersionCommand.java
+++ b/src/main/java/org/buildcli/commands/VersionCommand.java
@@ -4,7 +4,7 @@ import org.buildcli.BuildCLI;
 import org.buildcli.domain.BuildCLICommand;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "version", aliases = {"v"}, description = "Displays the current version of the CLI.", mixinStandardHelpOptions = true)
+@CommandLine.Command(name = "version", aliases = {"v"}, description = "Displays the current version of the BuildCLI.", mixinStandardHelpOptions = true)
 public class VersionCommand implements BuildCLICommand {
 
   @Override


### PR DESCRIPTION
Change requested by reviewer [@omatheusmesmo ] on PR #92 